### PR TITLE
DataType examples bugfix

### DIFF
--- a/templates/resource-response-content.nunjucks
+++ b/templates/resource-response-content.nunjucks
@@ -93,7 +93,7 @@
                     {% endif %}
 
                     {# Response - Array item examples #}
-                    {% set parent = b.items.examples %}
+                    {% set parent = b.items %}
                     {% include "./examples.nunjucks" %}
                 </div>
                 {% endif %}


### PR DESCRIPTION
./examples.nunjucks expects that "parent" variable contains object with "examples" property